### PR TITLE
use funcparserlib 1.0.0a1 or later

### DIFF
--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -5,3 +5,4 @@ sphinxcontrib-seqdiag
 https://github.com/shimizukawa/sphinxcontrib-feed/archive/master.zip
 sphinx-bootstrap-theme
 janome
+funcparserlib>=1.0.0a0


### PR DESCRIPTION
GitHub Actions で 0.3.5 がインストールされ、エラーになるため。
https://github.com/shimizukawa/freia.jp/runs/3911857624?check_suite_focus=true

```
Run echo "sphinx-build version $(/home/runner/.local/bin/sphinx-build --version) running"
sphinx-build version sphinx-build 4.2.0 running
Running Sphinx v4.2.0
loading translations [ja]... done

Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.8/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/runner/.local/lib/python3.8/site-packages/sphinx/application.py", line 237, in __init__
    self.setup_extension(extension)
  File "/home/runner/.local/lib/python3.8/site-packages/sphinx/application.py", line 393, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/runner/.local/lib/python3.8/site-packages/sphinx/registry.py", line 429, in load_extension
    mod = import_module(extname)
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 848, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/runner/.local/lib/python3.8/site-packages/sphinxcontrib/blockdiag.py", line 24, in <module>
    import blockdiag.utils.rst.nodes
  File "/home/runner/.local/lib/python3.8/site-packages/blockdiag/utils/rst/nodes.py", line 21, in <module>
    import blockdiag.builder
  File "/home/runner/.local/lib/python3.8/site-packages/blockdiag/builder.py", line 16, in <module>
    from blockdiag import parser
  File "/home/runner/.local/lib/python3.8/site-packages/blockdiag/parser.py", line 42, in <module>
    from funcparserlib.lexer import LexerError, Token, make_tokenizer
  File "/home/runner/.local/lib/python3.8/site-packages/funcparserlib/lexer.py", line 80
    def match_specs(specs, str, i, (line, pos)):
                                   ^
SyntaxError: invalid syntax

Exception occurred:
  File "/home/runner/.local/lib/python3.8/site-packages/blockdiag/parser.py", line 42, in <module>
    from funcparserlib.lexer import LexerError, Token, make_tokenizer
  File "/home/runner/.local/lib/python3.8/site-packages/funcparserlib/lexer.py", line 80
    def match_specs(specs, str, i, (line, pos)):
                                   ^
SyntaxError: invalid syntax
The full traceback has been saved in /tmp/sphinx-err-idc10nem.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```